### PR TITLE
Update to new twitter api and add timeout for robustness

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,7 @@
     "node-cron": "^2.0.3",
     "oauth": "^0.9.15",
     "redis": "^3.0.2",
-    "twitter-api-client": "^1.2.1",
+    "twitter-api-v2": "^1.6.5",
     "typechain": "^4.0.0"
   }
 }

--- a/app/src/alerts.ts
+++ b/app/src/alerts.ts
@@ -1,7 +1,7 @@
 import { discordAlertForArtBlock } from "./discord";
 import { getArtblockInfo } from "./artblocks_api";
 import { ArtBlockContract__factory } from "./contracts/factories/ArtBlockContract__factory";
-import { twitterClient, uploadTwitterImage, tweetArtblock } from "./twitter";
+import { tweetArtblock } from "./twitter";
 import axios from "axios";
 import * as fs from "fs";
 import delay = require("delay");
@@ -10,7 +10,7 @@ import {
   v2ArtBlocksContract,
   ethersProvider,
 } from "./ethereum";
-import { StatusesUpdate } from "twitter-api-client";
+import { TweetV1 } from "twitter-api-v2"
 
 export const alertForBlocks = async (
   startingBlock: number,
@@ -45,7 +45,7 @@ export const alertForBlocks = async (
 
     let tweetResp:
       | {
-          tweetRes: StatusesUpdate;
+          tweetRes: TweetV1;
           tweetUrl: string;
         }
       | undefined = undefined;

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -6,7 +6,6 @@ import {
 } from "./storage";
 import { getArtblockInfo } from "./artblocks_api";
 import { ArtBlockContract__factory } from "./contracts/factories/ArtBlockContract__factory";
-import { twitterClient, uploadTwitterImage, tweetArtblock } from "./twitter";
 import axios from "axios";
 import * as fs from "fs";
 import delay = require("delay");

--- a/app/src/twitter.ts
+++ b/app/src/twitter.ts
@@ -1,23 +1,40 @@
 import { config } from "./config";
-import { TwitterClient } from "twitter-api-client";
+import { TwitterApi } from "twitter-api-v2";
 import axios from "axios";
 import { ArtBlockInfo, ArtBlocksResponse } from "./artblocks_api";
 import { sleep } from "./utils";
 
 const IMAGE_RETRIES = 35;
 const IMAGE_RETRY_DELAY_MS = 25 * 1000;
+const TWITTER_TIMEOUT_MS = 14 * 1000;
 
-// console.log({config});
-export const twitterClient = new TwitterClient({
-  apiKey: config.twitterApiKey,
-  apiSecret: config.twitterApiSecret,
+export const twitterClientV2 = new TwitterApi({
+  appKey: config.twitterApiKey,
+  appSecret: config.twitterApiSecret,
   accessToken: config.twitterOauthToken,
-  accessTokenSecret: config.twitterOauthSecret,
+  accessSecret: config.twitterOauthSecret,
 });
 
 export interface Response {
   data: any;
 }
+
+function timeout(timeoutMs: number, failureMessage: string): Promise<never> {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => reject(failureMessage), timeoutMs);
+  });
+}
+
+const uploadTwitterMediaWithTimeout = async (
+  timeoutMs: number,
+  based: Buffer
+) => {
+  // use race function to timeout because twitter library doesn't timeout
+  return Promise.race([
+    timeout(TWITTER_TIMEOUT_MS, "Twitter post timed out"),
+    twitterClientV2.v1.uploadMedia(based, { type: "png" }),
+  ]);
+};
 
 const getImageResp = async (imageUrl: string): Promise<Response> => {
   for (let i = 0; i < IMAGE_RETRIES; i++) {
@@ -38,15 +55,18 @@ const getImageResp = async (imageUrl: string): Promise<Response> => {
 export const uploadTwitterImage = async (
   imageUrl: string
 ): Promise<string | undefined> => {
+  console.log("Getting image from artblocks at: ", imageUrl);
   const imageResp = await getImageResp(imageUrl);
   const imageData = imageResp.data as any;
-  const based = Buffer.from(imageData, "binary").toString("base64");
+  const based = Buffer.from(imageData, "binary");
 
   try {
-    const uploadRes = await twitterClient.media.mediaUpload({
-      media_data: based,
-    });
-    return uploadRes.media_id_string;
+    console.log("Uploading received image to Twitter");
+    const uploadRes = await uploadTwitterMediaWithTimeout(
+      TWITTER_TIMEOUT_MS,
+      based
+    );
+    return uploadRes;
   } catch (e) {
     console.error(e);
     return undefined;
@@ -67,14 +87,13 @@ export const tweetArtblock = async (artBlock: ArtBlockInfo) => {
     console.error("no media id returned, not tweeting");
     return;
   }
-
+  console.log(`Uploaded image ${imageUrl} complete. Tweeting...`);
   const tweetText = `${artBlock.name} minted${
     artBlock.mintedBy ? ` by ${artBlock.mintedBy}` : ""
   }. \n\n https://artblocks.io/token/${artBlock.tokenID}`;
   console.log(`Tweeting ${tweetText}`);
 
-  const tweetRes = await twitterClient.tweets.statusesUpdate({
-    status: tweetText,
+  const tweetRes = await twitterClientV2.v1.tweet(tweetText, {
     media_ids: mediaId,
   });
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -436,11 +436,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.3.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
 bech32@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
@@ -468,14 +463,6 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
-
-buffer@^5.6.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
-  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.1.13"
 
 chalk@^2.4.1:
   version "2.4.2"
@@ -679,11 +666,6 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-ieee754@^1.1.13:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -777,13 +759,6 @@ oauth@^0.9.15:
   version "0.9.15"
   resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.9.15.tgz#bd1fefaf686c96b75475aed5196412ff60cfb9c1"
   integrity sha1-vR/vr2hslrdUda7VGWQS/2DPucE=
-
-object-sizeof@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/object-sizeof/-/object-sizeof-1.6.1.tgz#35971f3fd2102bd8b51c67b0a53ed773ff77ab56"
-  integrity sha512-gNKGcRnDRXwEpAdwUY3Ef+aVZIrcQVXozSaVzHz6Pv4JxysH8vf5F+nIgsqW5T/YNwZNveh0mIW7PEH1O2MrDw==
-  dependencies:
-    buffer "^5.6.0"
 
 once@^1.3.0:
   version "1.4.0"
@@ -916,13 +891,10 @@ ts-node@^9.0.0:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-twitter-api-client@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/twitter-api-client/-/twitter-api-client-1.2.1.tgz#191748d2b44282fa29f41adc8e537aa63b2565bd"
-  integrity sha512-Y4g+arUVpPm7Uh7oAaigMXAKrILk6PNIlLqrAZq+sU2mG0kRBIQ5Gqq01NK4MftHaGtwuYSjA0M97NSyj6GiOQ==
-  dependencies:
-    oauth "^0.9.15"
-    object-sizeof "^1.6.1"
+twitter-api-v2@^1.6.5:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/twitter-api-v2/-/twitter-api-v2-1.6.5.tgz#881ff1ed2cd0f165897213f65b022a4bf265d71b"
+  integrity sha512-lmUZBth2N4l2eQC+aav3PO5U4K6p8IVd/fvJgZczBnIGxFo0HQpkBZFSvj86eKaUTIo5DU+UWVD7JgeaAlesgg==
 
 typechain@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Previously used twitter api had about 20% chance of locking the entire javascript process if image uploaded to Twitter exceeded image size limits. This was noticed noticed because the bot was fixed up about a week ago, and 11/12/2021 had a project with very large image sizes.

The fix implemented here is:

- Update to a newer Twitter client library that doesn't lock up javascript
- Wrap the Twitter image upload in a timeout to avoid locking up the bot if Twitter take a long time to respond
 