### PR TITLE
Remove support for handling mint #0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 A twitter bot that:
 
-- Posts every newly minted Art Block NFT to Twitter (@artblocksmints)
-- Posts every newly minted Art Block NFT to Discord in the `artblocks-mints` channel
+- Posts every newly minted Art Block NFT[^1] to Twitter (@artblocksmints)
+- Posts every newly minted Art Block NFT[^1] to Discord in the `artblocks-mints` channel
 
 ## Deployment
 
@@ -33,3 +33,5 @@ Accidental tweets may be deleted via Twitter's api by running the following scri
 ```
 yarn delete-tweet <tweet-id>
 ```
+
+[^1]: Mint #0 for a new project will always be skipped by alertbot in the interest of preventing broken links, as mint #0 is usually performed before a project has been activated, in which case the Generator API for that project will not yet be publicly accessible in the interest of maintaining some artist privacy for accessing this data outside of direct contract calls during the development process. If you are a PBAB partner and would like to modify this behavior for your alertbot integration, please reach out! :)

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,11 +34,6 @@ const contractAllowed = (contract: string) => {
 }
 
 app.post('/', (req: any, res: any) => {
-  const isMintZero = (tokenId % 1e6) === 0
-  if (isMintZero) {
-
-  }
-
   // Return early if webhook request is unauthorized.
   if(!allowed(req.get('webhook_secret'))) {
     // https://httpwg.org/specs/rfc7235.html#status.401

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,6 @@ app.post('/', (req: any, res: any) => {
 
   // Return early if token has not been modified.
   if(newData == null || oldData.image_id) {
-  } else {
     // https://httpwg.org/specs/rfc7232.html#status.304
     res.status(304).json({status: 'not modified'})
     return

--- a/src/test/mocks/webhook.ts
+++ b/src/test/mocks/webhook.ts
@@ -106,6 +106,60 @@ export const webhookDataMint0: any = {
     }
 }
 
+export const webhookDataUnknownContract: any = {
+    "event": {
+        "session_variables": {
+            "x-hasura-role": "admin"
+        },
+        "op": "UPDATE",
+        "data": {
+            "old": {
+                "hash": "0xff092bc9ae13a68e862681800017c2513c8a530c3bc04e671dd98a6d2174d35f",
+                "contract_address": "0x7f268357a8c2552623316e2562d90e642bb538e5",
+                "updated_at": "2022-01-03T15:16:32.558546",
+                "project_id": "0x7f268357a8c2552623316e2562d90e642bb538e5-3",
+                "features": {},
+                "minted_at": "2022-01-03T15:15:09+00:00",
+                "id": "0x7f268357a8c2552623316e2562d90e642bb538e5-3000000",
+                "image_id": null,
+                "invocation": 0,
+                "owner_address": "0xbe37a8b986f44cf527d393ba9f5a24bf0c16e31e",
+                "token_id": "3000000"
+            },
+            "new": {
+                "hash": "0xff092bc9ae13a68e862681800017c2513c8a530c3bc04e671dd98a6d2174d35f",
+                "contract_address": "0x7f268357a8c2552623316e2562d90e642bb538e5",
+                "updated_at": "2022-01-03T15:17:20.01335",
+                "project_id": "0x7f268357a8c2552623316e2562d90e642bb538e5-3",
+                "features": {},
+                "minted_at": "2022-01-03T15:15:09+00:00",
+                "id": "0x7f268357a8c2552623316e2562d90e642bb538e5-3000000",
+                "image_id": 2133,
+                "invocation": 0,
+                "owner_address": "0xbe37a8b986f44cf527d393ba9f5a24bf0c16e31e",
+                "token_id": "3000000"
+            }
+        },
+        "trace_context": {
+            "trace_id": "c6ab598fb5594e5c",
+            "span_id": "802f5b77440788eb"
+        }
+    },
+    "created_at": "2022-01-03T15:17:20.01335Z",
+    "id": "3c450896-bf20-4d7d-8da6-88d024ea82bc",
+    "delivery_info": {
+        "max_retries": 1,
+        "current_retry": 1
+    },
+    "trigger": {
+        "name": "minted_with_image"
+    },
+    "table": {
+        "schema": "public",
+        "name": "tokens_metadata"
+    }
+}
+
 export const webhookDataChangeInImage: any = {
     "event": {
         "session_variables": {

--- a/src/test/mocks/webhook.ts
+++ b/src/test/mocks/webhook.ts
@@ -10,18 +10,7 @@ export const webhookDataMint: any = {
                 "contract_address": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25",
                 "updated_at": "2022-01-03T15:16:32.558546",
                 "project_id": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25-3",
-                "features": {
-                    "Rotation": "Variable",
-                    "Style": "Solid",
-                    "Gaps": 0,
-                    "Color": "Sequence",
-                    "Bounce": "Yes",
-                    "Mode": "Dark",
-                    "Width": 0.25,
-                    "Bars": 8,
-                    "Orientation": "Horizontal",
-                    "Arrangement": "Linear"
-                },
+                "features": {},
                 "minted_at": "2022-01-03T15:15:09+00:00",
                 "id": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25-3000291",
                 "image_id": null,
@@ -34,18 +23,7 @@ export const webhookDataMint: any = {
                 "contract_address": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25",
                 "updated_at": "2022-01-03T15:17:20.01335",
                 "project_id": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25-3",
-                "features": {
-                    "Rotation": "Variable",
-                    "Style": "Solid",
-                    "Gaps": 0,
-                    "Color": "Sequence",
-                    "Bounce": "Yes",
-                    "Mode": "Dark",
-                    "Width": 0.25,
-                    "Bars": 8,
-                    "Orientation": "Horizontal",
-                    "Arrangement": "Linear"
-                },
+                "features": {},
                 "minted_at": "2022-01-03T15:15:09+00:00",
                 "id": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25-3000291",
                 "image_id": 2133,
@@ -74,6 +52,59 @@ export const webhookDataMint: any = {
     }
 }
 
+export const webhookDataMint0: any = {
+    "event": {
+        "session_variables": {
+            "x-hasura-role": "admin"
+        },
+        "op": "UPDATE",
+        "data": {
+            "old": {
+                "hash": "0xff092bc9ae13a68e862681800017c2513c8a530c3bc04e671dd98a6d2174d35f",
+                "contract_address": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25",
+                "updated_at": "2022-01-03T15:16:32.558546",
+                "project_id": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25-3",
+                "features": {},
+                "minted_at": "2022-01-03T15:15:09+00:00",
+                "id": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25-3000000",
+                "image_id": null,
+                "invocation": 0,
+                "owner_address": "0xbe37a8b986f44cf527d393ba9f5a24bf0c16e31e",
+                "token_id": "3000000"
+            },
+            "new": {
+                "hash": "0xff092bc9ae13a68e862681800017c2513c8a530c3bc04e671dd98a6d2174d35f",
+                "contract_address": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25",
+                "updated_at": "2022-01-03T15:17:20.01335",
+                "project_id": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25-3",
+                "features": {},
+                "minted_at": "2022-01-03T15:15:09+00:00",
+                "id": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25-3000000",
+                "image_id": 2133,
+                "invocation": 0,
+                "owner_address": "0xbe37a8b986f44cf527d393ba9f5a24bf0c16e31e",
+                "token_id": "3000000"
+            }
+        },
+        "trace_context": {
+            "trace_id": "c6ab598fb5594e5c",
+            "span_id": "802f5b77440788eb"
+        }
+    },
+    "created_at": "2022-01-03T15:17:20.01335Z",
+    "id": "3c450896-bf20-4d7d-8da6-88d024ea82bc",
+    "delivery_info": {
+        "max_retries": 1,
+        "current_retry": 1
+    },
+    "trigger": {
+        "name": "minted_with_image"
+    },
+    "table": {
+        "schema": "public",
+        "name": "tokens_metadata"
+    }
+}
 
 export const webhookDataChangeInImage: any = {
     "event": {
@@ -87,18 +118,7 @@ export const webhookDataChangeInImage: any = {
                 "contract_address": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25",
                 "updated_at": "2022-01-03T15:16:32.558546",
                 "project_id": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25-3",
-                "features": {
-                    "Rotation": "Variable",
-                    "Style": "Solid",
-                    "Gaps": 0,
-                    "Color": "Sequence",
-                    "Bounce": "Yes",
-                    "Mode": "Dark",
-                    "Width": 0.25,
-                    "Bars": 8,
-                    "Orientation": "Horizontal",
-                    "Arrangement": "Linear"
-                },
+                "features": {},
                 "minted_at": "2022-01-03T15:15:09+00:00",
                 "id": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25-3000291",
                 "image_id": 1,
@@ -111,18 +131,7 @@ export const webhookDataChangeInImage: any = {
                 "contract_address": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25",
                 "updated_at": "2022-01-03T15:17:20.01335",
                 "project_id": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25-3",
-                "features": {
-                    "Rotation": "Variable",
-                    "Style": "Solid",
-                    "Gaps": 0,
-                    "Color": "Sequence",
-                    "Bounce": "Yes",
-                    "Mode": "Dark",
-                    "Width": 0.25,
-                    "Bars": 8,
-                    "Orientation": "Horizontal",
-                    "Arrangement": "Linear"
-                },
+                "features": {},
                 "minted_at": "2022-01-03T15:15:09+00:00",
                 "id": "0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25-3000291",
                 "image_id": 2133,

--- a/src/test/server.ts
+++ b/src/test/server.ts
@@ -1,4 +1,4 @@
-import { webhookDataMint, webhookDataMint0, webhookDataChangeInImage } from "./mocks/webhook";
+import { webhookDataMint, webhookDataMint0, webhookDataUnknownContract, webhookDataChangeInImage } from "./mocks/webhook";
 
 //During the test the env variable is set to test
 process.env.NODE_ENV = 'test';
@@ -27,6 +27,15 @@ describe('/ receives hasura webhook', () => {
         .send(webhookDataMint0)
         .end((err: any, res: any) => {
           res.should.have.status(418);
+          done()
+        });
+  });
+  it('receives webhook for unknown contract and returns 501', (done) => {
+    chai.request(app)
+        .post('/')
+        .send(webhookDataUnknownContract)
+        .end((err: any, res: any) => {
+          res.should.have.status(501);
           done()
         });
   });

--- a/src/test/server.ts
+++ b/src/test/server.ts
@@ -12,12 +12,12 @@ let should = chai.should();
 chai.use(chaiHttp);
 
 describe('/ receives hasura webhook', () => {
-  it('receives webhook with new image_id and returns 200', (done) => {
+  it('receives webhook with new image_id and returns 202', (done) => {
     chai.request(app)
         .post('/')
         .send(webhookDataMint)
         .end((err: any, res: any) => {
-          res.should.have.status(200);
+          res.should.have.status(202);
           done()
         });
   });

--- a/src/test/server.ts
+++ b/src/test/server.ts
@@ -1,4 +1,4 @@
-import { webhookDataMint, webhookDataChangeInImage } from "./mocks/webhook";
+import { webhookDataMint, webhookDataMint0, webhookDataChangeInImage } from "./mocks/webhook";
 
 //During the test the env variable is set to test
 process.env.NODE_ENV = 'test';
@@ -18,6 +18,15 @@ describe('/ receives hasura webhook', () => {
         .send(webhookDataMint)
         .end((err: any, res: any) => {
           res.should.have.status(202);
+          done()
+        });
+  });
+  it('receives webhook with mint 0 and returns 418', (done) => {
+    chai.request(app)
+        .post('/')
+        .send(webhookDataMint0)
+        .end((err: any, res: any) => {
+          res.should.have.status(418);
           done()
         });
   });


### PR DESCRIPTION
This PR does three things:
1. removes handling by alertbot of mint #0 mints (and clarifies this in the repo documentation)
1. updates alertbot's status response handling to match a bit more closely the different possible failure/success modes
1. adds a couple more tests

If we'd like to revisit more complicated logic for 1. in the future–or even remove this altogether for PBAB partners on their request–we can definitely do so, but I think this is the simplest way to address https://app.asana.com/0/1201517173861745/1201967395454694/f for now.

@Jbern16 I think this topic had come up briefly in an unrelated discussion, but I do think we should just remove support for handling #0 altogether rather than doing any checks on activation status as I think may have previously been discussed briefly IIRC.