### PR TITLE
Adding staging to alertbot

### DIFF
--- a/src/api_data.ts
+++ b/src/api_data.ts
@@ -52,7 +52,7 @@ const getTokenResp = async (
     let tokenEndpoint;
     if (isArtblocksContract(contract)) {
       tokenEndpoint = `https://token.artblocks.io/${tokenId}`;
-    } else if (isArtblocksStagingContract) {
+    } else if (isArtblocksStagingContract(contract)) {
       tokenEndpoint = `https://token.staging.artblocks.io/${tokenId}`;
     } else {
       tokenEndpoint = `https://token.artblocks.io/${contract}/${tokenId}`;

--- a/src/api_data.ts
+++ b/src/api_data.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { config } from './config';
-import { isArtblocksContract } from './utils';
+import { isArtblocksContract, isArtblocksStagingContract } from './utils';
 
 export interface ArtBlocksResponse {
   platform: string;
@@ -52,6 +52,8 @@ const getTokenResp = async (
     let tokenEndpoint;
     if (isArtblocksContract(contract)) {
       tokenEndpoint = `https://token.artblocks.io/${tokenId}`;
+    } else if (isArtblocksStagingContract) {
+      tokenEndpoint = `https://token.staging.artblocks.io/${tokenId}`;
     } else {
       tokenEndpoint = `https://token.artblocks.io/${contract}/${tokenId}`;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,11 @@ export const config = {
     'discord webhook url',
     false
   ),
+  discordStagingMintsWebhookUrl: stringFromENVorThrow(
+    process.env.DISCORD_STAGING_MINTS_WEBHOOK_URL,
+    'discord webhook url for AB staging mints',
+    false
+  ),
   pbabDiscordWebhookUrl: stringFromENVorThrow(
     process.env.PBAB_DISCORD_WEBHOOK_URL,
     'discord webhook url for AB PBAB channel',

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,7 +1,7 @@
 import { ArtBlockInfo } from './api_data';
 import axios from 'axios';
 import { config } from './config';
-import { isArtblocksContract } from './utils';
+import { isArtblocksContract, isArtblocksStagingContract } from './utils';
 
 const discordAlertForArtBlock = async (artBlock: ArtBlockInfo) => {
   const title = artBlock.name;
@@ -24,12 +24,14 @@ const discordAlertForArtBlock = async (artBlock: ArtBlockInfo) => {
   );
 
   let discordWebhook = config.discordWebhookUrl;
-  if (
+  if (isArtblocksStagingContract(artBlock.contract)) {
+    discordWebhook = config.discordStagingMintsWebhookUrl;
+  } else if (
     !(process.env.IS_PBAB === 'true') &&
     !isArtblocksContract(artBlock.contract)
   ) {
     discordWebhook = config.pbabDiscordWebhookUrl;
-  }
+  } 
   return axios.post(discordWebhook, payload);
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { schedule } from 'node-cron';
 import { mintQueue, queueClean } from './mint_queue';
 import { config } from './config';
-import { isArtblocksContract, isPBABContract } from './utils';
+import { isArtblocksContract, isArtblocksStagingContract, isPBABContract } from './utils';
 
 require('dotenv').config();
 const express = require('express');
@@ -27,10 +27,11 @@ const contractAllowed = async (contract: string) => {
     contract.toLowerCase()
   );
   const isABContract = isArtblocksContract(contract);
+  const isABStagingContract = isArtblocksStagingContract(contract);
   const isPBAB = await isPBABContract(contract);
   return process.env.IS_PBAB === 'true'
     ? isMyPBABContract
-    : isPBAB || isABContract;
+    : isPBAB || isABContract || isABStagingContract;
 };
 
 app.post('/', async (req: any, res: any) => {

--- a/src/test/api_data.ts
+++ b/src/test/api_data.ts
@@ -57,6 +57,59 @@ describe('ArtBlocks api_data', () => {
   });
 });
 
+describe('ArtBlocks Staging api_data', () => {
+  before(() => {
+    process.env.IS_PBAB = 'false';
+    process.env.PBAB_CONTRACT = '';
+    process.env.THUMBNAIL_LOCATION =
+      'https://artblocks-mainthumb.s3.amazonaws.com';
+  });
+  describe('#getArtblockInfo', () => {
+    before(() => {
+      if (!nock.isActive()) nock.activate();
+      const tokenScope = nock('https://token.staging.artblocks.io')
+        .get('/1')
+        .reply(200, {
+          name: 'Recursion #1',
+          image: 'https://media.artblocks.io/1.png',
+          external_url: 'https://www.artblocks.io/token/1',
+        });
+      const imgScope = nock('https://artblocks-mainthumb.s3.amazonaws.com')
+        .get('/1.png')
+        .reply(200, {
+          data: new ArrayBuffer(8),
+        });
+      tokenScope;
+      imgScope;
+    });
+    afterEach(nock.cleanAll);
+    it('gets additional meta needed for alert', async () => {
+      const { name, image, external_url, imgBinary } = await getArtblockInfo(
+        '1',
+        '0xda62f67be7194775a75be91cbf9feedcc5776d4b'
+      );
+      assert.equal(name, 'Recursion #1');
+      assert.equal(image, 'https://media.artblocks.io/1.png');
+      assert.equal(external_url, 'https://www.artblocks.io/token/1');
+      const buffer = Buffer.isBuffer(imgBinary);
+      assert.equal(buffer, true);
+    });
+  });
+  describe('#getOpenseaInfo', () => {
+    const account = '0x104e1e2725dbbd2d75eb1a46e880932d2e1d4c12';
+    before(() => {
+      const openSeaScope = nock('https://api.opensea.io')
+        .get(`/account/${account}/`)
+        .reply(200, { data: { user: { username: 'ABKING123' } } });
+      openSeaScope;
+    });
+    it('gets owner data for alert', async () => {
+      const mintedBy = await getOpenseaInfo(account);
+      assert.equal(mintedBy, 'ABKING123');
+    });
+  });
+});
+
 describe('PBAB api_data', () => {
   before(() => {
     process.env.IS_PBAB = 'true';

--- a/src/test/mocks/webhook.ts
+++ b/src/test/mocks/webhook.ts
@@ -267,3 +267,111 @@ export const webhookDataChangeInImage: any = {
         "name": "tokens_metadata"
     }
 }
+
+export const webhookDataStagingMint: any = {
+  event: {
+    session_variables: {
+      'x-hasura-role': 'admin',
+    },
+    op: 'UPDATE',
+    data: {
+      old: {
+        hash: '0xff092bc9ae13a68e862681800017c2513c8a530c3bc04e671dd98a6d2174d35f',
+        contract_address: '0xda62f67be7194775a75be91cbf9feedcc5776d4b',
+        updated_at: '2022-01-03T15:16:32.558546',
+        project_id: '0xda62f67be7194775a75be91cbf9feedcc5776d4b-3',
+        features: {},
+        minted_at: '2022-01-03T15:15:09+00:00',
+        id: '0xda62f67be7194775a75be91cbf9feedcc5776d4b-3000291',
+        image_id: null,
+        invocation: 291,
+        owner_address: '0xbe37a8b986f44cf527d393ba9f5a24bf0c16e31e',
+        token_id: '3000291',
+      },
+      new: {
+        hash: '0xff092bc9ae13a68e862681800017c2513c8a530c3bc04e671dd98a6d2174d35f',
+        contract_address: '0xda62f67be7194775a75be91cbf9feedcc5776d4b',
+        updated_at: '2022-01-03T15:17:20.01335',
+        project_id: '0x87c6e93fc0b149ec59ad595e2e187a4e1d7fdc25-3',
+        features: {},
+        minted_at: '2022-01-03T15:15:09+00:00',
+        id: '0xda62f67be7194775a75be91cbf9feedcc5776d4b-3000291',
+        image_id: 2133,
+        invocation: 291,
+        owner_address: '0xbe37a8b986f44cf527d393ba9f5a24bf0c16e31e',
+        token_id: '3000291',
+      },
+    },
+    trace_context: {
+      trace_id: 'c6ab598fb5594e5c',
+      span_id: '802f5b77440788eb',
+    },
+  },
+  created_at: '2022-01-03T15:17:20.01335Z',
+  id: '3c450896-bf20-4d7d-8da6-88d024ea82bc',
+  delivery_info: {
+    max_retries: 1,
+    current_retry: 1,
+  },
+  trigger: {
+    name: 'minted_with_image',
+  },
+  table: {
+    schema: 'public',
+    name: 'tokens_metadata',
+  },
+};
+
+export const webhookDataStagingMint0: any = {
+  event: {
+    session_variables: {
+      'x-hasura-role': 'admin',
+    },
+    op: 'UPDATE',
+    data: {
+      old: {
+        hash: '0xff092bc9ae13a68e862681800017c2513c8a530c3bc04e671dd98a6d2174d35f',
+        contract_address: '0xda62f67be7194775a75be91cbf9feedcc5776d4b',
+        updated_at: '2022-01-03T15:16:32.558546',
+        project_id: '0xda62f67be7194775a75be91cbf9feedcc5776d4b-3',
+        features: {},
+        minted_at: '2022-01-03T15:15:09+00:00',
+        id: '0xda62f67be7194775a75be91cbf9feedcc5776d4b-3000000',
+        image_id: null,
+        invocation: 0,
+        owner_address: '0xbe37a8b986f44cf527d393ba9f5a24bf0c16e31e',
+        token_id: '3000000',
+      },
+      new: {
+        hash: '0xff092bc9ae13a68e862681800017c2513c8a530c3bc04e671dd98a6d2174d35f',
+        contract_address: '0xda62f67be7194775a75be91cbf9feedcc5776d4b',
+        updated_at: '2022-01-03T15:17:20.01335',
+        project_id: '0xda62f67be7194775a75be91cbf9feedcc5776d4b-3',
+        features: {},
+        minted_at: '2022-01-03T15:15:09+00:00',
+        id: '0xda62f67be7194775a75be91cbf9feedcc5776d4b-3000000',
+        image_id: 2133,
+        invocation: 0,
+        owner_address: '0xbe37a8b986f44cf527d393ba9f5a24bf0c16e31e',
+        token_id: '3000000',
+      },
+    },
+    trace_context: {
+      trace_id: 'c6ab598fb5594e5c',
+      span_id: '802f5b77440788eb',
+    },
+  },
+  created_at: '2022-01-03T15:17:20.01335Z',
+  id: '3c450896-bf20-4d7d-8da6-88d024ea82bc',
+  delivery_info: {
+    max_retries: 1,
+    current_retry: 1,
+  },
+  trigger: {
+    name: 'minted_with_image',
+  },
+  table: {
+    schema: 'public',
+    name: 'tokens_metadata',
+  },
+};

--- a/src/test/server.ts
+++ b/src/test/server.ts
@@ -4,6 +4,8 @@ import {
   webhookDataSkippedProject,
   webhookDataUnknownContract,
   webhookDataChangeInImage,
+  webhookDataStagingMint,
+  webhookDataStagingMint0,
 } from './mocks/webhook';
 
 //During the test the env variable is set to test
@@ -124,6 +126,32 @@ describe('PBAB / receives hasura webhook', () => {
       .send(webhookDataChangeInImage)
       .end((err: any, res: any) => {
         res.should.have.status(304);
+        done();
+      });
+  });
+});
+
+describe('ArtBlocks Staging / receives hasura webhook', () => {
+  before(() => {
+    process.env.IS_PBAB = 'false';
+  });
+  it('receives webhook with new image_id and returns 202', (done) => {
+    chai
+      .request(app)
+      .post('/')
+      .send(webhookDataStagingMint)
+      .end((err: any, res: any) => {
+        res.should.have.status(202);
+        done();
+      });
+  });
+  it('receives webhook with mint 0 and returns 418', (done) => {
+    chai
+      .request(app)
+      .post('/')
+      .send(webhookDataStagingMint0)
+      .end((err: any, res: any) => {
+        res.should.have.status(418);
         done();
       });
   });

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -78,7 +78,7 @@ export const sendToTwitter = async (artBlock: ArtBlockInfo) => {
     !(process.env.IS_PBAB === 'true') &&
     !isArtblocksContract(artBlock.contract)
   ) {
-    // Do not tweet from AB mint account if PBAB mint event
+    // Do not tweet from AB mint account if PBAB or staging mint event
     return;
   }
   let tweetResp:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,8 +8,14 @@ export const AB_CONTRACTS =
         '0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270',
       ];
 
+export const AB_STAGING_CONTRACTS = ['0xda62f67be7194775a75be91cbf9feedcc5776d4b'];
+
 export function isArtblocksContract(contract: string): boolean {
   return AB_CONTRACTS.includes(contract.toLowerCase());
+}
+
+export function isArtblocksStagingContract(contract: string): boolean {
+  return AB_STAGING_CONTRACTS.includes(contract.toLowerCase());
 }
 
 export async function isPBABContract(contract: string): Promise<boolean> {


### PR DESCRIPTION
## What's New
- Community team wants to change #ab-art-chat to post mints from staging projects to generate buzz around upcoming projects
- Should be as simple as making this PR change, and updating a few env vars

https://app.asana.com/0/1201568815538912/1202998512374222/f

## TODO Post-Merge
- Update the alertbot URL env var in staging Hasura to point towards the prod alertbot proxy
- Add the env var added in this PR to Heroku - pointed towards a webhook in the test server first to make sure it works properly